### PR TITLE
Feature : 체험 예약 가능 시간 및 날짜 필드 추가

### DIFF
--- a/src/main/java/com/InFrame/domains/experience/controller/api/ExperienceApi.java
+++ b/src/main/java/com/InFrame/domains/experience/controller/api/ExperienceApi.java
@@ -24,11 +24,21 @@ public interface ExperienceApi {
                             @ExampleObject(value = """
                                     {
                                         "experienceId": 1,
-                                        "hostId": 12,
-                                        "title": "한 입의 예술, 핸드메이드 초콜릿",
-                                        "description": "저희 체험은 100년 째 이어지고 있는 머시기 ... (생략)",
-                                        "price": 50000,
-                                        "time" : 3
+                                            "hostId": 1,
+                                            "title": "한 입의 예술, 핸드메이드 초콜릿",
+                                            "description": "저희 체험은 100년 째 이어지고 있는 머시기 ,, (생략)",
+                                            "price": 50000,
+                                            "durationInHours": 3,
+                                            "maxCapacityPerSlot": 3,
+                                            "availableDaysOfWeek": [
+                                                "SUNDAY",
+                                                "MONDAY"
+                                            ],
+                                            "availableTimes": [
+                                                "09:00:00",
+                                                "11:00:00",
+                                                "14:00:00"
+                                            ]
                                     }
                                     """)
                     })),

--- a/src/main/java/com/InFrame/domains/experience/entity/Experience.java
+++ b/src/main/java/com/InFrame/domains/experience/entity/Experience.java
@@ -1,16 +1,26 @@
 package com.InFrame.domains.experience.entity;
 
 import com.InFrame.domains.host.entity.Host;
+import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity
 @Getter
@@ -21,26 +31,53 @@ public class Experience {
     private Long id;
 
     @Column(nullable = false)
-    private String title; // 체험 이름
+    private String title; // 체험 제목
 
     @Column(columnDefinition = "TEXT")
     private String description; // 체험 설명
 
     @Column(nullable = false)
-    private int price; // 체험 가격
+    private int price; // 체험 기본 가격
 
     @Column(nullable = false)
-    private int time; // 체험 시간
+    private int durationInHours; // 체험  소요 시간 (시간 단위)
+
+    @Column(nullable = false)
+    private int maxCapacityPerSlot; // 각 시간 당 예약 가능한 최대 인원
+
+    // 예약 가능한 요일 목록
+    @ElementCollection(targetClass = DayOfWeek.class, fetch = FetchType.LAZY)
+    @Enumerated(EnumType.STRING)
+    @CollectionTable(name = "experience_available_days", joinColumns = @JoinColumn(name = "experience_id")) // 테이블명 변경
+    @Column(name = "day_of_week", nullable = false)
+    private Set<DayOfWeek> availableDaysOfWeek = new HashSet<>();
+
+    // 예약 가능한 시간 목록
+    @ElementCollection(targetClass = LocalTime.class, fetch = FetchType.LAZY)
+    @CollectionTable(name = "experience_available_times", joinColumns = @JoinColumn(name = "experience_id"))
+    @Column(name = "available_time", nullable = false)
+    private Set<LocalTime> availableTimes = new HashSet<>();
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "host_id")
     private Host host;
 
     @Builder
     public Experience(String title, String description, int price,
-                      int time, Host host) {
+                      int durationInHours, int maxCapacityPerSlot,
+                      Set<DayOfWeek> availableDaysOfWeek, Set<LocalTime> availableTimes,
+                      Host host) {
         this.title = title;
         this.description = description;
         this.price = price;
-        this.time = time;
+        this.durationInHours = durationInHours;
+        this.maxCapacityPerSlot = maxCapacityPerSlot;
+        if (availableDaysOfWeek != null) {
+            this.availableDaysOfWeek = availableDaysOfWeek;
+        }
+        if (availableTimes != null) {
+            this.availableTimes = availableTimes;
+        }
+        this.host = host;
     }
 }

--- a/src/main/java/com/InFrame/domains/experience/reqdto/ExperienceRequestDto.java
+++ b/src/main/java/com/InFrame/domains/experience/reqdto/ExperienceRequestDto.java
@@ -4,7 +4,12 @@ import com.InFrame.domains.experience.entity.Experience;
 import com.InFrame.domains.host.entity.Host;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.Set;
 
 @Schema(description = "체험 생성 요청 DTO")
 public record ExperienceRequestDto (
@@ -12,17 +17,28 @@ public record ExperienceRequestDto (
         @NotBlank(message = "체험 제목은 필수 입력입니다.")
         String title,
 
-        @Schema(description = "체험 소개", example = "저희 체험은 100년 째 이어지고 있는 머시기 ,, (생략)")
-        @NotBlank(message = "체험 소개는 필수 입력입니다.")
+        @Schema(description = "체험 설명", example = "저희 체험은 100년 째 이어지고 있는 머시기 ,, (생략)")
+        @NotBlank(message = "체험 설명은 필수 입력입니다.")
         String description,
 
         @Schema(description = "체험 가격", example = "50000")
         @NotNull(message = "체험 가격은 필수 입력입니다.")
-        int price,
+        Integer price,
 
         @Schema(description = "체험 시간", example = "3")
         @NotNull(message = "체험 시간은 필수 입력입니다.")
-        int time
+        Integer durationInHours,
+
+        @Schema(description = "최대 예약 가능 인원")
+        Integer maxCapacityPerSlot,
+
+        @NotEmpty(message = "예약 가능 요일은 최소 하나 이상 선택해야 합니다.")
+        @Schema(description = "예약 가능 요일 목록 (영문 대문자)", example = "[\"MONDAY\", \"SUNDAY\"]")
+        Set<DayOfWeek> availableDaysOfWeek,
+
+        @NotEmpty(message = "예약 가능 시간은 최소 하나 이상 선택해야 합니다.")
+        @Schema(description = "예약 가능한 시작 시간 목록 (HH:mm 형식)", example = "[\"09:00\", \"11:00\", \"14:00\"]")
+        Set<LocalTime> availableTimes
 ){
     public Experience toEntity(Host host) {
         return Experience.builder()
@@ -30,7 +46,10 @@ public record ExperienceRequestDto (
                 .title(title)
                 .description(description)
                 .price(price)
-                .time(time)
+                .durationInHours(durationInHours)
+                .maxCapacityPerSlot(maxCapacityPerSlot)
+                .availableDaysOfWeek(availableDaysOfWeek)
+                .availableTimes(availableTimes)
                 .build();
     }
 }

--- a/src/main/java/com/InFrame/domains/experience/resdto/ExperienceResponseDto.java
+++ b/src/main/java/com/InFrame/domains/experience/resdto/ExperienceResponseDto.java
@@ -2,14 +2,24 @@ package com.InFrame.domains.experience.resdto;
 
 import com.InFrame.domains.experience.entity.Experience;
 import com.InFrame.domains.host.entity.Host;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.Set;
+
+@Schema(description = "체험 정보 응답 DTO")
 public record ExperienceResponseDto (
         Long experienceId,
         Long hostId,
         String title,
         String description,
         int price,
-        int time
+        int durationInHours,
+        int maxCapacityPerSlot,
+        Set<DayOfWeek> availableDaysOfWeek,
+        Set<LocalTime> availableTimes
+
 ) {
     public static  ExperienceResponseDto from(Experience experience, Host host) {
         return  new ExperienceResponseDto(
@@ -18,7 +28,10 @@ public record ExperienceResponseDto (
                 experience.getTitle(),
                 experience.getDescription(),
                 experience.getPrice(),
-                experience.getTime()
+                experience.getDurationInHours(),
+                experience.getMaxCapacityPerSlot(),
+                experience.getAvailableDaysOfWeek(),
+                experience.getAvailableTimes()
         );
     }
 }

--- a/src/main/java/com/InFrame/domains/experience/service/ExperienceService.java
+++ b/src/main/java/com/InFrame/domains/experience/service/ExperienceService.java
@@ -20,10 +20,14 @@ public class ExperienceService {
     // 체험 생성
     public ExperienceResponseDto createExperience(User user, ExperienceRequestDto requestDto) {
         if (user.getRole() != Role.HOST) {
-            throw new CustomException(ErrorCode.USER_NOT_HOST);
+            throw new CustomException(ErrorCode.FORBIDDEN_ACCESS);
         }
 
         Host host = user.getHost();
+
+        if (host == null) {
+            throw new CustomException(ErrorCode.HOST_NOT_FOUND);
+        }
 
         Experience experience = requestDto.toEntity(host);
 


### PR DESCRIPTION
## 배경
- 체험을 생성할 때 요일과 시간이 필요하기 때문

## 작업사항
- 체험 예약 가능 시간 및 날짜 필드와 체험 생성에 필요한 필드 추가 (26423e446ee0bbe48f2bd144619f69e7855736bc,
38e487b4ccd3e75838656c7753a0f52f9b448d12,
62fb7a76f964b9b11c6c1b1325767a63de783d9c)
- 체험 생성 시 호스트 정보가 없을 경우 예외처리 추가 (bdfdaaa0638929547656174b915dd5b969454307)
- Swagger 수정 (4a409f3edeef74714ec548008c3e6d74c91e4a1b)