### PR TITLE
Feature : 호스트 사업자 번호 검증 및 지도 정보 필드 추가

### DIFF
--- a/.github/workflows/docker-depoly.yml
+++ b/.github/workflows/docker-depoly.yml
@@ -68,4 +68,5 @@ jobs:
               -e AWS_ACCESS_KEY=${{ secrets.AWS_ACCESS_KEY }} \
               -e AWS_SECRET_KEY=${{ secrets.AWS_SECRET_KEY }} \
               -e AWS_S3_BUCKET_NAME=${{ secrets.AWS_S3_BUCKET_NAME }} \
+              -e PUBLIC_DATA_SERVICE_KEY=${{ secrests.PUBLIC_DATA_SERVICE_KEY }} \
               ${{ secrets.DOCKERHUB_USERNAME }}/inframe-was:develop

--- a/.github/workflows/docker-depoly.yml
+++ b/.github/workflows/docker-depoly.yml
@@ -68,5 +68,5 @@ jobs:
               -e AWS_ACCESS_KEY=${{ secrets.AWS_ACCESS_KEY }} \
               -e AWS_SECRET_KEY=${{ secrets.AWS_SECRET_KEY }} \
               -e AWS_S3_BUCKET_NAME=${{ secrets.AWS_S3_BUCKET_NAME }} \
-              -e PUBLIC_DATA_SERVICE_KEY=${{ secrests.PUBLIC_DATA_SERVICE_KEY }} \
+              -e PUBLIC_DATA_SERVICE_KEY=${{ secrets.PUBLIC_DATA_SERVICE_KEY }} \
               ${{ secrets.DOCKERHUB_USERNAME }}/inframe-was:develop

--- a/src/main/java/com/InFrame/common/config/AppConfig.java
+++ b/src/main/java/com/InFrame/common/config/AppConfig.java
@@ -1,0 +1,14 @@
+package com.InFrame.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/InFrame/common/dto/BusinessValidationRequestDto.java
+++ b/src/main/java/com/InFrame/common/dto/BusinessValidationRequestDto.java
@@ -1,0 +1,9 @@
+package com.InFrame.common.dto;
+
+import java.util.List;
+
+// API 요청
+public record BusinessValidationRequestDto (
+        List<String> b_no
+){
+}

--- a/src/main/java/com/InFrame/common/dto/BusinessValidationResponseDto.java
+++ b/src/main/java/com/InFrame/common/dto/BusinessValidationResponseDto.java
@@ -1,0 +1,45 @@
+package com.InFrame.common.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public record BusinessValidationResponseDto(
+        @JsonProperty("status_code")
+        String statusCode,
+
+        @JsonProperty("match_cnt")
+        int matchCnt,
+
+        @JsonProperty("data")
+        List<BusinessStatusDto> data
+) {
+    // "data" 배열 내부 객체
+    public record BusinessStatusDto(
+            @JsonProperty("b_no")
+            String b_no, // 사업자번호
+
+            @JsonProperty("b_stt")
+            String b_stt, // "계속사업자", "휴업자", "폐업자"
+
+            @JsonProperty("b_stt_cd")
+            String b_stt_cd, // "01", "02", "03"
+
+            @JsonProperty("tax_type")
+            String tax_type, // "부가가치세 일반과세자" 등
+
+            @JsonProperty("tax_type_cd")
+            String tax_type_cd,
+
+            @JsonProperty("end_dt")
+            String end_dt, // 폐업일자
+
+            @JsonProperty("utcc_yn")
+            String utcc_yn, // 단위과세전환여부
+
+            @JsonProperty("tax_type_change_dt")
+            String tax_type_change_dt, // 최근과세유형전환일자
+
+            @JsonProperty("invoice_apply_dt")
+            String invoice_apply_dt // 세금계산서적용일자
+    ) {}
+}

--- a/src/main/java/com/InFrame/common/exception/error/ErrorCode.java
+++ b/src/main/java/com/InFrame/common/exception/error/ErrorCode.java
@@ -37,8 +37,13 @@ public enum ErrorCode {
     // 이미지 관련 오류
     FILE_IS_EMPTY(404, "파일이 비어있습니다."),
     FILE_UPLOAD_FAILED(400, "파일 업로드에 실패하였습니다."),
-    INVALID_FILE_URL(400, "잘못된 경로입니다.");
+    INVALID_FILE_URL(400, "잘못된 경로입니다."),
 
+    // 사업자 번호 조회 관련 오류
+    INVALID_BUSINESS_NUMBER_FORMAT(400, "사업자 번호 형식이 올바르지 않습니다."),
+    INVALID_BUSINESS_NUMBER(400, "국세청에 등록되지 않은 사업자 번호입니다."),
+    INACTIVE_BUSINESS_NUMBER(400, "휴업 또는 폐업 상태의 사업자입니다."),
+    BUSINESS_API_FAILED(500, "사업자 번호 조회 API 호출에 실패했습니다.");
     private final int status;
     private final String message;
 }

--- a/src/main/java/com/InFrame/common/service/BusinessValidationService.java
+++ b/src/main/java/com/InFrame/common/service/BusinessValidationService.java
@@ -1,0 +1,84 @@
+package com.InFrame.common.service;
+
+import com.InFrame.common.dto.BusinessValidationRequestDto;
+import com.InFrame.common.dto.BusinessValidationResponseDto;
+import com.InFrame.common.exception.CustomException;
+import com.InFrame.common.exception.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Collections;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BusinessValidationService {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${api.public-data.validate-url}")
+    private String apiUrl;
+
+    @Value("${api.public-data.service-key}")
+    private String serviceKey;
+
+    public boolean validateBusinessNumber(String businessNumber) {
+        // 1. 10자리 숫자인지 간단히 확인
+        if (businessNumber == null || !businessNumber.matches("\\d{10}")) {
+            throw new CustomException(ErrorCode.INVALID_BUSINESS_NUMBER_FORMAT);
+        }
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+        headers.set("Authorization", "Infuser " + serviceKey);
+
+        BusinessValidationRequestDto requestBody = new BusinessValidationRequestDto(List.of(businessNumber));
+        HttpEntity<BusinessValidationRequestDto> entity = new HttpEntity<>(requestBody, headers);
+
+        try {
+            ResponseEntity<BusinessValidationResponseDto> response = restTemplate.postForEntity(
+                    apiUrl, entity, BusinessValidationResponseDto.class
+            );
+
+            BusinessValidationResponseDto responseBody = response.getBody();
+
+            // 2. 응답이 비어있거나, data가 없거나, match_cnt가 0이면 조회 실패
+            if (responseBody == null || responseBody.data() == null
+                    || responseBody.data().isEmpty() || responseBody.matchCnt() == 0) {
+                throw new CustomException(ErrorCode.INVALID_BUSINESS_NUMBER);
+            }
+
+            // 3. 응답 본문의 data[0]에서 상태 코드 확인
+            BusinessValidationResponseDto.BusinessStatusDto statusDto = responseBody.data().get(0);
+
+            // 4. b_stt_cd (사업자 상태 코드) 확인
+            switch (statusDto.b_stt_cd()) {
+                case "01": // 계속사업자
+                    return true;
+                case "02": // 휴업자
+                case "03": // 폐업자
+                    throw new CustomException(ErrorCode.INACTIVE_BUSINESS_NUMBER);
+                default:
+                    throw new CustomException(ErrorCode.INVALID_BUSINESS_NUMBER);
+            }
+
+        } catch (HttpClientErrorException e) {
+            log.error("[Business API Error] Client Error: {}, Body: {}", e.getStatusCode(), e.getResponseBodyAsString());
+            throw new CustomException(ErrorCode.BUSINESS_API_FAILED);
+        } catch (RestClientException e) {
+            log.error("[Business API Error] RestClientException: {}", e.getMessage());
+            throw new CustomException(ErrorCode.BUSINESS_API_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/InFrame/domains/host/controller/HostController.java
+++ b/src/main/java/com/InFrame/domains/host/controller/HostController.java
@@ -8,9 +8,11 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -25,6 +27,13 @@ public class HostController implements HostApi {
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @RequestBody @Valid HostRequestDto hostRequestDto) {
         hostService.changeToHost(userDetails.getUser(), hostRequestDto);
+        return ResponseEntity.ok().build();
+    }
+
+    @Override
+    @GetMapping("/check-business-number")
+    public ResponseEntity<?> checkBusinessNumber(@RequestParam String businessNumber) {
+        hostService.validateBusinessNumber(businessNumber);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/InFrame/domains/host/controller/api/HostApi.java
+++ b/src/main/java/com/InFrame/domains/host/controller/api/HostApi.java
@@ -3,6 +3,7 @@ package com.InFrame.domains.host.controller.api;
 import com.InFrame.domains.host.reqdto.HostRequestDto;
 import com.InFrame.security.userdetails.UserDetailsImpl;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -12,6 +13,7 @@ import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Host API", description = "호스트 관련 API")
 public interface HostApi {
@@ -51,5 +53,23 @@ public interface HostApi {
     ResponseEntity<?> changeToHost(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @RequestBody @Valid HostRequestDto hostRequestDto
+    );
+
+    @Operation(summary = "사업자 번호 검증", description = "DB 중복 확인 및 공공데이터 API를 통해 유효한 사업자 번호인지 검증합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "확인되었습니다. (사용 가능한 번호)"),
+            // ... (이전 단계에서 제안한 400, 409, 500 ApiResponse들) ...
+            @ApiResponse(responseCode = "400", description = "유효하지 않은 사업자 번호 (형식 오류, 휴/폐업 등)",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "형식 오류", value = "{\"status\": 400, \"message\": \"사업자 번호 형식이 올바르지 않습니다.\"}"),
+                            @ExampleObject(name = "미등록", value = "{\"status\": 400, \"message\": \"국세청에 등록되지 않은 사업자 번호입니다.\"}"),
+                            @ExampleObject(name = "휴/폐업", value = "{\"status\": 400, \"message\": \"휴업 또는 폐업 상태의 사업자입니다.\"}")
+                    })),
+            @ApiResponse(responseCode = "409", description = "이미 등록된 사업자 번호입니다."),
+            @ApiResponse(responseCode = "500", description = "API 조회 실패")
+    })
+    ResponseEntity<?> checkBusinessNumber(
+            @Parameter(description = "검증할 사업자 번호", required = true, example = "1234567890")
+            @RequestParam String businessNumber
     );
 }

--- a/src/main/java/com/InFrame/domains/host/entity/Host.java
+++ b/src/main/java/com/InFrame/domains/host/entity/Host.java
@@ -36,6 +36,21 @@ public class Host {
     @Column
     private String kakaoAddress; // 카카오톡 채널 주소
 
+    @Column(length = 25)
+    private String description; // 호스트 소개
+
+    @Column(nullable = false)
+    private Double latitude; // 위도
+
+    @Column(nullable = false)
+    private Double longitude; // 경도
+
+    @Column(nullable = false)
+    private String addressBase; // 기본 주소
+
+    @Column
+    private String addressDetail; // 상세 주소
+
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user; // User 와 1:1
@@ -43,12 +58,20 @@ public class Host {
     @Builder
     public Host(String businessName, String businessPhoneNumber,
                 String businessEmail, String kakaoAddress,
-                String businessNumber, User user) {
+                String businessNumber, String description,
+                Double latitude, Double longitude,
+                String addressBase, String addressDetail,
+                User user) {
         this.businessNumber = businessNumber;
         this.businessName = businessName;
         this.businessPhoneNumber = businessPhoneNumber;
         this.businessEmail = businessEmail;
         this.kakaoAddress = kakaoAddress;
+        this.description = description;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.addressBase = addressBase;
+        this.addressDetail = addressDetail;
         this.user = user;
     }
 }

--- a/src/main/java/com/InFrame/domains/host/reqdto/HostRequestDto.java
+++ b/src/main/java/com/InFrame/domains/host/reqdto/HostRequestDto.java
@@ -5,6 +5,7 @@ import com.InFrame.domains.user.entity.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 @Schema(description = "호스트로 변경 요청 DTO")
 public record HostRequestDto(
@@ -16,16 +17,34 @@ public record HostRequestDto(
         @NotBlank(message = "사업자명은 필수 입력입니다.")
         String businessName,
 
-        @Schema(description = "고객센터 전화번호", example = "111-1111")
+        @Schema(description = "고객센터 전화번호", example = "010-0000-0000")
         @NotBlank(message = "고객센터 전화번호는 필수 입력입니다.")
         String businessPhoneNumber,
 
-        @Schema(description = "고객센터 이메일", example = "abcd1234@gmail.com")
+        @Schema(description = "고객센터 이메일", example = "inGyeongsan@yu.ac.kr")
         @Email(message = "이메일 형식을 맞춰주세요.")
         String businessEmail,
 
         @Schema(description = "카카오톡 채널 주소", example = "https://pf.kakao.com/채널주소")
-        String kakaoAddress
+        String kakaoAddress,
+
+        @Schema(description = "호스트 소개", example = "흙을 담아 삶의 이야기를 빚어냅니다.")
+        String description,
+
+        @Schema(description = "위도", example = "37.5665")
+        @NotNull(message = "위도는 필수입니다.")
+        Double latitude,
+
+        @Schema(description = "경도", example = "126.9780")
+        @NotNull(message = "경도는 필수입니다.")
+        Double longitude,
+
+        @Schema(description = "기본 주소 (도로명/지번)", example = "서울 중구 세종대로 110")
+        @NotBlank(message = "기본 주소는 필수입니다.")
+        String addressBase,
+
+        @Schema(description = "상세 주소 (선택)", example = "2층")
+        String addressDetail
 ) {
     public Host toEntity(User user) {
         return Host.builder()
@@ -35,6 +54,11 @@ public record HostRequestDto(
                 .businessPhoneNumber(businessPhoneNumber)
                 .businessEmail(businessEmail)
                 .kakaoAddress(kakaoAddress)
+                .description(description)
+                .latitude(latitude)
+                .longitude(longitude)
+                .addressBase(addressBase)
+                .addressDetail(addressDetail)
                 .build();
     }
 }

--- a/src/main/java/com/InFrame/domains/host/service/HostService.java
+++ b/src/main/java/com/InFrame/domains/host/service/HostService.java
@@ -2,6 +2,7 @@ package com.InFrame.domains.host.service;
 
 import com.InFrame.common.exception.CustomException;
 import com.InFrame.common.exception.error.ErrorCode;
+import com.InFrame.common.service.BusinessValidationService;
 import com.InFrame.domains.host.entity.Host;
 import com.InFrame.domains.host.repository.HostRepository;
 import com.InFrame.domains.host.reqdto.HostRequestDto;
@@ -18,24 +19,32 @@ import org.springframework.transaction.annotation.Transactional;
 public class HostService {
     private final HostRepository hostRepository;
     private final UserRepository userRepository;
+    private final BusinessValidationService businessValidationService;
 
+    // 호스트로 변경
     public void changeToHost(User user, HostRequestDto hostRequestDto) {
         if (user.getRole() == Role.HOST) {
             throw new CustomException(ErrorCode.USER_ALREADY_HOST);
         }
 
-        if (hostRepository.existsByBusinessNumber(hostRequestDto.businessNumber())) {
-            throw new CustomException(ErrorCode.BUSINESS_NUMBER_ALREADY_EXISTS);
-        }
-
-        // =======================================================================
-        // TODO: 공공데이터 포털 API 복구 시 로직 구현
-        // =======================================================================
+        validateBusinessNumber(hostRequestDto.businessNumber());
 
         user.updateRole(Role.HOST);
         userRepository.save(user);
 
         Host host = hostRequestDto.toEntity(user);
         hostRepository.save(host);
+    }
+
+    // 사업자 번호 검증
+    @Transactional(readOnly = true)
+    public void validateBusinessNumber(String businessNumber) {
+        // 1. DB에서 중복 확인
+        if (hostRepository.existsByBusinessNumber(businessNumber)) {
+            throw new CustomException(ErrorCode.BUSINESS_NUMBER_ALREADY_EXISTS);
+        }
+
+        // 2. 공공데이터 API로 유효성 및 상태 확인
+        businessValidationService.validateBusinessNumber(businessNumber);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -69,3 +69,8 @@ jwt:
 app:
   oauth2:
     redirect-url: ${OAUTH2_REDIRECT_URL:http://localhost:3000/oauth-redirect}
+
+api:
+  public-data:
+    service-key: ${PUBLIC_DATA_SERVICE_KEY}
+    validate-url: "https://api.odcloud.kr/api/nts-businessman/v1/status"


### PR DESCRIPTION
## 배경
- 호스트로 변경할 때 사업자 번호를 검증 후 변경을 위해
- 호스트 정보의 지도 정보가 필요해서

## 작업사항
- Host 엔티티 지도정보 필드 추가 (44b099b05b00c996aaae31895342e21e312fb44a)
- 외부 API 통신을 위해 RestTemplate 을 빈 등록 (9e305d0beccf0bcab305ff6505079ea9e71dcf99)
- 사업자 번호 검증 로직 (151afa011812465255e70a1ee199e2fa0d9cb4be, e24267d14c98fdd6ad3e043db4018558a5e3d0b7)