### PR TITLE
Feature : eunm 타입 추가 및 필드 추가, 스웨거 작성

### DIFF
--- a/src/main/java/com/InFrame/domains/experience/controller/EnumController.java
+++ b/src/main/java/com/InFrame/domains/experience/controller/EnumController.java
@@ -1,0 +1,44 @@
+package com.InFrame.domains.experience.controller;
+
+import com.InFrame.domains.experience.entity.enums.Category;
+import com.InFrame.domains.experience.entity.enums.DetailField;
+import com.InFrame.domains.experience.entity.enums.ProfessionalField;
+import com.InFrame.domains.experience.resdto.EnumResponseDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/v1/enums")
+public class EnumController {
+    @GetMapping("/categories")
+    public ResponseEntity<?> getCategory() {
+        List<EnumResponseDto> categories = Arrays.stream(Category.values())
+                .map(category -> new EnumResponseDto(category.name(), category.getDescription()))
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(categories);
+    }
+
+    @GetMapping("/detailFields")
+    public ResponseEntity<?> getDetailField() {
+        List<EnumResponseDto> detailFields = Arrays.stream(DetailField.values())
+                .map(detailField -> new EnumResponseDto(detailField.name(), detailField.getDescription()))
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(detailFields);
+    }
+
+    @GetMapping("/professionalFields")
+    public ResponseEntity<?> getProfessionalField() {
+        List<EnumResponseDto> professionalFields = Arrays.stream(ProfessionalField.values())
+                .map(professionalField -> new EnumResponseDto(professionalField.name(), professionalField.getDescription()))
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(professionalFields);
+    }
+
+
+}

--- a/src/main/java/com/InFrame/domains/experience/controller/EnumController.java
+++ b/src/main/java/com/InFrame/domains/experience/controller/EnumController.java
@@ -1,5 +1,6 @@
 package com.InFrame.domains.experience.controller;
 
+import com.InFrame.domains.experience.controller.api.EnumApi;
 import com.InFrame.domains.experience.entity.enums.Category;
 import com.InFrame.domains.experience.entity.enums.DetailField;
 import com.InFrame.domains.experience.entity.enums.ProfessionalField;
@@ -15,7 +16,8 @@ import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/v1/enums")
-public class EnumController {
+public class EnumController implements EnumApi {
+    @Override
     @GetMapping("/categories")
     public ResponseEntity<?> getCategory() {
         List<EnumResponseDto> categories = Arrays.stream(Category.values())
@@ -24,6 +26,7 @@ public class EnumController {
         return ResponseEntity.ok(categories);
     }
 
+    @Override
     @GetMapping("/detailFields")
     public ResponseEntity<?> getDetailField() {
         List<EnumResponseDto> detailFields = Arrays.stream(DetailField.values())
@@ -32,6 +35,7 @@ public class EnumController {
         return ResponseEntity.ok(detailFields);
     }
 
+    @Override
     @GetMapping("/professionalFields")
     public ResponseEntity<?> getProfessionalField() {
         List<EnumResponseDto> professionalFields = Arrays.stream(ProfessionalField.values())

--- a/src/main/java/com/InFrame/domains/experience/controller/api/EnumApi.java
+++ b/src/main/java/com/InFrame/domains/experience/controller/api/EnumApi.java
@@ -1,0 +1,43 @@
+package com.InFrame.domains.experience.controller.api;
+
+import com.InFrame.domains.experience.resdto.EnumResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Tag(name = "Enum", description = "Enum-based 필드 옵션 조회 API")
+public interface EnumApi {
+
+    @Operation(summary = "분야 카테고리 Enum 목록 조회", description = "체험 등록에 필요한 '분야 카테고리' Enum 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "카테고리 목록 조회 성공",
+                    content = @Content(mediaType = "application/json",
+                            array = @ArraySchema(schema = @Schema(implementation = EnumResponseDto.class))))
+    })
+    @GetMapping("/categories")
+    ResponseEntity<?> getCategory();
+
+    @Operation(summary = "상세분야 Enum 목록 조회", description = "체험 등록에 필요한 '상세분야' Enum 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "상세분야 목록 조회 성공",
+                    content = @Content(mediaType = "application/json",
+                            array = @ArraySchema(schema = @Schema(implementation = EnumResponseDto.class))))
+    })
+    @GetMapping("/detailFields")
+    ResponseEntity<?> getDetailField();
+
+    @Operation(summary = "전문분야 Enum 목록 조회", description = "체험 등록에 필요한 '전문분야' Enum 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "전문분야 목록 조회 성공",
+                    content = @Content(mediaType = "application/json",
+                            array = @ArraySchema(schema = @Schema(implementation = EnumResponseDto.class))))
+    })
+    @GetMapping("/professionalFields")
+    ResponseEntity<?> getProfessionalField();
+}

--- a/src/main/java/com/InFrame/domains/experience/entity/Experience.java
+++ b/src/main/java/com/InFrame/domains/experience/entity/Experience.java
@@ -1,5 +1,8 @@
 package com.InFrame.domains.experience.entity;
 
+import com.InFrame.domains.experience.entity.enums.Category;
+import com.InFrame.domains.experience.entity.enums.DetailField;
+import com.InFrame.domains.experience.entity.enums.ProfessionalField;
 import com.InFrame.domains.host.entity.Host;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
@@ -29,6 +32,24 @@ public class Experience {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Category category; // 분야 카테고리
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ProfessionalField professionalField; // 전문분야
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private DetailField detailField; // 상세분야
+
+    @Column(columnDefinition = "TEXT")
+    private String certifications; // 보유한 자격증
+
+    @Column(columnDefinition = "TEXT")
+    private String companyInfo; // 업체 정보
 
     @Column(nullable = false)
     private String title; // 체험 제목
@@ -63,10 +84,17 @@ public class Experience {
     private Host host;
 
     @Builder
-    public Experience(String title, String description, int price,
-                      int durationInHours, int maxCapacityPerSlot,
+    public Experience(Category category, ProfessionalField professionalField,
+                      DetailField detailField, String title, String description,
+                      String certifications, String companyInfo,
+                      int price, int durationInHours, int maxCapacityPerSlot,
                       Set<DayOfWeek> availableDaysOfWeek, Set<LocalTime> availableTimes,
                       Host host) {
+        this.category = category;
+        this.professionalField = professionalField;
+        this.detailField = detailField;
+        this.certifications = certifications;
+        this.companyInfo = companyInfo;
         this.title = title;
         this.description = description;
         this.price = price;

--- a/src/main/java/com/InFrame/domains/experience/entity/enums/Category.java
+++ b/src/main/java/com/InFrame/domains/experience/entity/enums/Category.java
@@ -1,0 +1,9 @@
+package com.InFrame.domains.experience.entity.enums;
+
+// 분야 카테고리
+public enum Category {
+    MASTER_ARTISAN, // 장인, 명인
+    YOUNG_ENTREPRENEUR, // 청년사업가
+    LOCAL_MERCHANT, // 골목상인
+    ARTIST // 예술가, 문화인
+}

--- a/src/main/java/com/InFrame/domains/experience/entity/enums/Category.java
+++ b/src/main/java/com/InFrame/domains/experience/entity/enums/Category.java
@@ -1,9 +1,16 @@
 package com.InFrame.domains.experience.entity.enums;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
 // 분야 카테고리
+@Getter
+@RequiredArgsConstructor
 public enum Category {
-    MASTER_ARTISAN, // 장인, 명인
-    YOUNG_ENTREPRENEUR, // 청년사업가
-    LOCAL_MERCHANT, // 골목상인
-    ARTIST // 예술가, 문화인
+    MASTER_ARTISAN("장인/명인"),
+    YOUNG_ENTREPRENEUR("청년사업가"),
+    LOCAL_MERCHANT("골목상인"),
+    ARTIST("예술인/문화인");
+
+    private final String description;
 }

--- a/src/main/java/com/InFrame/domains/experience/entity/enums/DetailField.java
+++ b/src/main/java/com/InFrame/domains/experience/entity/enums/DetailField.java
@@ -1,13 +1,20 @@
 package com.InFrame.domains.experience.entity.enums;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
 // 상세분야
+@Getter
+@RequiredArgsConstructor
 public enum DetailField {
-    CERAMIC_CRAFT, // 도자기 공예
-    LEATHER_CRAFT, // 가죽 공예
-    METAL_SILVER_CRAFT,  // 금속, 은공예
-    SOAP_CANDLE_DIFFUSER, // 비누, 캔들, 디퓨저 제작
-    WOOD_CRAFT, // 목공예
-    DRAWING_WATERCOLOR, // 드로잉, 수채화
-    PERFUME_MAKING, // 향수 만들기
-    KNITTING_EMBROIDERY // 뜨개, 자수 클래스
+    CERAMIC_CRAFT("도자기 공예"),
+    LEATHER_CRAFT("가죽 공예"),
+    METAL_SILVER_CRAFT("금속/은공예"),
+    SOAP_CANDLE_DIFFUSER("비누/캔들/디퓨저 제작"),
+    WOOD_CRAFT("목공예"),
+    DRAWING_WATERCOLOR("드로잉/수채화"),
+    PERFUME_MAKING("향수 만들기"),
+    KNITTING_EMBROIDERY("뜨개/자수 클래스");
+
+    private final String description;
 }

--- a/src/main/java/com/InFrame/domains/experience/entity/enums/DetailField.java
+++ b/src/main/java/com/InFrame/domains/experience/entity/enums/DetailField.java
@@ -1,0 +1,13 @@
+package com.InFrame.domains.experience.entity.enums;
+
+// 상세분야
+public enum DetailField {
+    CERAMIC_CRAFT, // 도자기 공예
+    LEATHER_CRAFT, // 가죽 공예
+    METAL_SILVER_CRAFT,  // 금속, 은공예
+    SOAP_CANDLE_DIFFUSER, // 비누, 캔들, 디퓨저 제작
+    WOOD_CRAFT, // 목공예
+    DRAWING_WATERCOLOR, // 드로잉, 수채화
+    PERFUME_MAKING, // 향수 만들기
+    KNITTING_EMBROIDERY // 뜨개, 자수 클래스
+}

--- a/src/main/java/com/InFrame/domains/experience/entity/enums/ProfessionalField.java
+++ b/src/main/java/com/InFrame/domains/experience/entity/enums/ProfessionalField.java
@@ -1,0 +1,13 @@
+package com.InFrame.domains.experience.entity.enums;
+
+// 전문분야
+public enum ProfessionalField {
+    CRAFT_CREATION, // 공예, 창작
+    FOOD_DESSERT, // 음식, 디저트
+    FLOWER_GARDENING, // 플라워, 가드닝
+    CULTURE_TRADITION, // 문화, 전통체험
+    MUSIC_ART, // 음악/예술
+    LIFE_HEALING, // 라이프, 힐링
+    LOCAL_TOUR, // 지역탐방/체험투어
+    PHOTO_CONTENT // 사진, 콘텐츠
+}

--- a/src/main/java/com/InFrame/domains/experience/entity/enums/ProfessionalField.java
+++ b/src/main/java/com/InFrame/domains/experience/entity/enums/ProfessionalField.java
@@ -1,13 +1,20 @@
 package com.InFrame.domains.experience.entity.enums;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
 // 전문분야
+@Getter
+@RequiredArgsConstructor
 public enum ProfessionalField {
-    CRAFT_CREATION, // 공예, 창작
-    FOOD_DESSERT, // 음식, 디저트
-    FLOWER_GARDENING, // 플라워, 가드닝
-    CULTURE_TRADITION, // 문화, 전통체험
-    MUSIC_ART, // 음악/예술
-    LIFE_HEALING, // 라이프, 힐링
-    LOCAL_TOUR, // 지역탐방/체험투어
-    PHOTO_CONTENT // 사진, 콘텐츠
+    CRAFT_CREATION("공예/창작"),
+    FOOD_DESSERT("음식/디저트"),
+    FLOWER_GARDENING("플라워/가드닝"),
+    CULTURE_TRADITION("문화/전통체험"),
+    MUSIC_ART("음악/예술"),
+    LIFE_HEALING("라이프/힐링"),
+    LOCAL_TOUR("지역탐방/체험투어"),
+    PHOTO_CONTENT("사진/콘텐츠");
+
+    private final String description;
 }

--- a/src/main/java/com/InFrame/domains/experience/reqdto/ExperienceRequestDto.java
+++ b/src/main/java/com/InFrame/domains/experience/reqdto/ExperienceRequestDto.java
@@ -1,6 +1,9 @@
 package com.InFrame.domains.experience.reqdto;
 
 import com.InFrame.domains.experience.entity.Experience;
+import com.InFrame.domains.experience.entity.enums.Category;
+import com.InFrame.domains.experience.entity.enums.DetailField;
+import com.InFrame.domains.experience.entity.enums.ProfessionalField;
 import com.InFrame.domains.host.entity.Host;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
@@ -13,6 +16,24 @@ import java.util.Set;
 
 @Schema(description = "체험 생성 요청 DTO")
 public record ExperienceRequestDto (
+        @Schema(description = "분야 카테고리")
+        @NotNull(message = "분야 카테고리는 필수입니다.")
+        Category category,
+
+        @Schema(description = "전문분야")
+        @NotNull(message = "전문분야는 필수입니다.")
+        ProfessionalField professionalField,
+
+        @Schema(description = "상세분야")
+        @NotNull(message = "상세분야는 필수입니다.")
+        DetailField detailField,
+
+        @Schema(description = "보유한 자격증", example = "한식조리기능사, 바리스타 1급")
+        String certifications,
+
+        @Schema(description = "업체 정보", example = "동민카페")
+        String companyInfo,
+
         @Schema(description = "체험 제목", example = "한 입의 예술, 핸드메이드 초콜릿")
         @NotBlank(message = "체험 제목은 필수 입력입니다.")
         String title,
@@ -43,6 +64,11 @@ public record ExperienceRequestDto (
     public Experience toEntity(Host host) {
         return Experience.builder()
                 .host(host)
+                .category(category)
+                .professionalField(professionalField)
+                .detailField(detailField)
+                .certifications(certifications)
+                .companyInfo(companyInfo)
                 .title(title)
                 .description(description)
                 .price(price)

--- a/src/main/java/com/InFrame/domains/experience/resdto/EnumResponseDto.java
+++ b/src/main/java/com/InFrame/domains/experience/resdto/EnumResponseDto.java
@@ -1,0 +1,14 @@
+package com.InFrame.domains.experience.resdto;
+
+import lombok.Getter;
+
+@Getter
+public class EnumResponseDto {
+    private final String code;
+    private final String description;
+
+    public EnumResponseDto(String code, String description) {
+        this.code = code;
+        this.description = description;
+    }
+}

--- a/src/main/java/com/InFrame/domains/experience/resdto/EnumResponseDto.java
+++ b/src/main/java/com/InFrame/domains/experience/resdto/EnumResponseDto.java
@@ -1,14 +1,4 @@
 package com.InFrame.domains.experience.resdto;
 
-import lombok.Getter;
-
-@Getter
-public class EnumResponseDto {
-    private final String code;
-    private final String description;
-
-    public EnumResponseDto(String code, String description) {
-        this.code = code;
-        this.description = description;
-    }
+public record EnumResponseDto(String code, String description) {
 }


### PR DESCRIPTION
## 배경
- 호스트가 체험 생성 시 카테고리, 전문분야, 상세분야가 필요
- 채험 생성 시 업체정보, 보유한 자격증이 필요

## 작업사항
- Enum(분야, 전문분야, 상세분야) 추가 (83bc04798651a21d4814a8aca3f4879645ddad01)
- enum, 자격증, 업체정보 필드 추가 (ffd620ead6f2901c64f59637707ba3e0e62b3676)
- Swagger 작성 (35b40ef0c7b6bd8d8910014ec1c9be338ee448d5)