### PR TITLE
Feature : 전체 호스트 조회 및 호스트 자신 정보 조회 로직 구현

### DIFF
--- a/src/main/java/com/InFrame/domains/experience/repository/ExperienceRepository.java
+++ b/src/main/java/com/InFrame/domains/experience/repository/ExperienceRepository.java
@@ -5,8 +5,12 @@ import com.InFrame.domains.host.entity.Host;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ExperienceRepository extends JpaRepository<Experience, Long> {
     // 호스트가 등록한 모든 체험 찾기
     List<Experience> findAllByHost(Host host);
+
+    // 호스트의 체험 중 첫 번째 데이터를 가져옴
+    Optional<Experience> findTopByHost(Host host);
 }

--- a/src/main/java/com/InFrame/domains/host/controller/HostController.java
+++ b/src/main/java/com/InFrame/domains/host/controller/HostController.java
@@ -2,6 +2,8 @@ package com.InFrame.domains.host.controller;
 
 import com.InFrame.domains.host.controller.api.HostApi;
 import com.InFrame.domains.host.reqdto.HostRequestDto;
+import com.InFrame.domains.host.resdto.HostMapResponseDto;
+import com.InFrame.domains.host.resdto.MyHostInfoResponseDto;
 import com.InFrame.domains.host.service.HostService;
 import com.InFrame.security.userdetails.UserDetailsImpl;
 import jakarta.validation.Valid;
@@ -17,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -51,5 +54,22 @@ public class HostController implements HostApi {
         String logoUrl = hostService.uploadCompanyLogo(userDetails.getUser(), file);
 
         return ResponseEntity.ok(Map.of("companyLogoUrl", logoUrl));
+    }
+
+    @Override
+    @GetMapping("/map")
+    public ResponseEntity<?> getAllHostsForMap() {
+        List<HostMapResponseDto> hostList = hostService.getAllHostsForMap();
+        return ResponseEntity.ok(hostList);
+    }
+
+    @Override
+    @GetMapping("/me")
+    // [수정]
+    public ResponseEntity<?> getMyHostInfo(
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        MyHostInfoResponseDto hostInfo = hostService.getMyHostInfo(userDetails.getUser());
+        return ResponseEntity.ok(hostInfo);
     }
 }

--- a/src/main/java/com/InFrame/domains/host/controller/api/HostApi.java
+++ b/src/main/java/com/InFrame/domains/host/controller/api/HostApi.java
@@ -1,17 +1,22 @@
 package com.InFrame.domains.host.controller.api;
 
 import com.InFrame.domains.host.reqdto.HostRequestDto;
+import com.InFrame.domains.host.resdto.HostMapResponseDto;
+import com.InFrame.domains.host.resdto.MyHostInfoResponseDto;
 import com.InFrame.security.userdetails.UserDetailsImpl;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.multipart.MultipartFile;
@@ -59,7 +64,6 @@ public interface HostApi {
     @Operation(summary = "사업자 번호 검증", description = "DB 중복 확인 및 공공데이터 API를 통해 유효한 사업자 번호인지 검증합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "확인되었습니다. (사용 가능한 번호)"),
-            // ... (이전 단계에서 제안한 400, 409, 500 ApiResponse들) ...
             @ApiResponse(responseCode = "400", description = "유효하지 않은 사업자 번호 (형식 오류, 휴/폐업 등)",
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(name = "형식 오류", value = "{\"status\": 400, \"message\": \"사업자 번호 형식이 올바르지 않습니다.\"}"),
@@ -95,5 +99,27 @@ public interface HostApi {
 
             @Parameter(description = "업로드할 로고 이미지 파일 (form-data key: 'file')", required = true)
             @RequestParam("file") MultipartFile file
+    );
+
+    @Operation(summary = "전체 호스트 목록 조회 (지도용)", description = "지도에 표시하기 위한 모든 호스트의 간략한 정보를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(mediaType = "application/json",
+                            array = @ArraySchema(schema = @Schema(implementation = HostMapResponseDto.class))))
+    })
+    ResponseEntity<?> getAllHostsForMap();
+
+    @Operation(summary = "내 호스트 정보 조회", description = "인증된 호스트의 상세 정보를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = MyHostInfoResponseDto.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "호스트 권한이 없습니다."),
+            @ApiResponse(responseCode = "404", description = "호스트 정보를 찾을 수 없습니다.")
+    })
+    ResponseEntity<?> getMyHostInfo(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal UserDetailsImpl userDetails
     );
 }

--- a/src/main/java/com/InFrame/domains/host/resdto/HostMapResponseDto.java
+++ b/src/main/java/com/InFrame/domains/host/resdto/HostMapResponseDto.java
@@ -1,0 +1,48 @@
+package com.InFrame.domains.host.resdto;
+
+import com.InFrame.domains.experience.entity.enums.DetailField;
+import com.InFrame.domains.host.entity.Host;
+import com.InFrame.domains.host.entity.enums.Category;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "지도 표시용 호스트 정보 응답 DTO")
+public record HostMapResponseDto(
+        @Schema(description = "호스트 ID")
+        Long hostId,
+        @Schema(description = "사업자명")
+        String businessName,
+        @Schema(description = "호스트 본명")
+        String hostName,
+        @Schema(description = "호스트 프로필 이미지")
+        String profileImageUrl,
+        @Schema(description = "분야 카테고리")
+        Category category,
+        @Schema(description = "체험 세부 분야", nullable = true)
+        DetailField detailField,
+        @Schema(description = "위도")
+        Double latitude,
+        @Schema(description = "경도")
+        Double longitude,
+        @Schema(description = "기본 주소")
+        String addressBase,
+        @Schema(description = "업체 로고 이미지 URL")
+        String companyLogoUrl,
+        @Schema(description = "호스트가 받은 총 리뷰 수")
+        long reviewCount
+) {
+    public static HostMapResponseDto from(Host host, long reviewCount, DetailField detailField) {
+        return new HostMapResponseDto(
+                host.getId(),
+                host.getBusinessName(),
+                host.getUser().getName(),
+                host.getUser().getProfileImageUrl(),
+                host.getCategory(),
+                detailField,
+                host.getLatitude(),
+                host.getLongitude(),
+                host.getAddressBase(),
+                host.getCompanyLogoUrl(),
+                reviewCount
+        );
+    }
+}

--- a/src/main/java/com/InFrame/domains/host/resdto/MyHostInfoResponseDto.java
+++ b/src/main/java/com/InFrame/domains/host/resdto/MyHostInfoResponseDto.java
@@ -1,0 +1,24 @@
+package com.InFrame.domains.host.resdto;
+
+import com.InFrame.domains.host.entity.Host;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "내 호스트 정보 응답 DTO")
+public record MyHostInfoResponseDto(
+        @Schema(description = "호스트 본명")
+        String hostName,
+
+        @Schema(description = "호스트 프로필 이미지")
+        String profileImageUrl,
+
+        @Schema(description = "호스트 소개")
+        String description
+) {
+    public static MyHostInfoResponseDto from(Host host) {
+        return new MyHostInfoResponseDto(
+                host.getUser().getName(),
+                host.getUser().getProfileImageUrl(),
+                host.getDescription()
+        );
+    }
+}

--- a/src/main/java/com/InFrame/domains/host/service/HostService.java
+++ b/src/main/java/com/InFrame/domains/host/service/HostService.java
@@ -4,9 +4,15 @@ import com.InFrame.common.exception.CustomException;
 import com.InFrame.common.exception.error.ErrorCode;
 import com.InFrame.common.service.BusinessValidationService;
 import com.InFrame.common.service.S3UploadService;
+import com.InFrame.domains.experience.entity.Experience;
+import com.InFrame.domains.experience.entity.enums.DetailField;
+import com.InFrame.domains.experience.repository.ExperienceRepository;
 import com.InFrame.domains.host.entity.Host;
 import com.InFrame.domains.host.repository.HostRepository;
 import com.InFrame.domains.host.reqdto.HostRequestDto;
+import com.InFrame.domains.host.resdto.HostMapResponseDto;
+import com.InFrame.domains.host.resdto.MyHostInfoResponseDto;
+import com.InFrame.domains.review.repository.ReviewRepository;
 import com.InFrame.domains.user.entity.Role;
 import com.InFrame.domains.user.entity.User;
 import com.InFrame.domains.user.repository.UserRepository;
@@ -14,6 +20,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Transactional
@@ -23,6 +33,8 @@ public class HostService {
     private final UserRepository userRepository;
     private final BusinessValidationService businessValidationService;
     private final S3UploadService s3UploadService;
+    private final ReviewRepository reviewRepository;
+    private final ExperienceRepository experienceRepository;
 
     // 호스트로 변경
     public void changeToHost(User user, HostRequestDto hostRequestDto) {
@@ -79,5 +91,38 @@ public class HostService {
         hostRepository.save(host);
 
         return newLogoUrl;
+    }
+
+    // 지도 표시용 전체 호스트 목록 조회
+    @Transactional(readOnly = true)
+    public List<HostMapResponseDto> getAllHostsForMap() {
+        return hostRepository.findAll().stream()
+                .map(host -> {
+                    long reviewCount = reviewRepository.countByReservation_Experience_Host(host);
+
+                    DetailField detailField = null;
+                    Optional<Experience> firstExperience = experienceRepository.findTopByHost(host);
+                    if (firstExperience.isPresent()) {
+                        detailField = firstExperience.get().getDetailField();
+                    }
+
+                    return HostMapResponseDto.from(host, reviewCount, detailField);
+                })
+                .collect(Collectors.toList());
+    }
+
+    // 호스트 자신 정보 조회
+    @Transactional(readOnly = true)
+    public MyHostInfoResponseDto getMyHostInfo(User user) {
+        // 1. 호스트 권한 확인
+        if (user.getRole() != Role.HOST) {
+            throw new CustomException(ErrorCode.FORBIDDEN_ACCESS);
+        }
+        // 2. 호스트 정보 가져오기
+        Host host = user.getHost();
+        if (host == null) {
+            throw new CustomException(ErrorCode.HOST_NOT_FOUND);
+        }
+        return MyHostInfoResponseDto.from(host);
     }
 }

--- a/src/main/java/com/InFrame/domains/review/repository/ReviewRepository.java
+++ b/src/main/java/com/InFrame/domains/review/repository/ReviewRepository.java
@@ -1,6 +1,6 @@
 package com.InFrame.domains.review.repository;
 
-import com.InFrame.domains.experience.entity.Experience;
+import com.InFrame.domains.host.entity.Host;
 import com.InFrame.domains.review.entity.Review;
 import com.InFrame.domains.review.resdto.ReviewResponseDto;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,6 +11,9 @@ import java.util.List;
 import java.util.Optional;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+    // 호스트의 리뷰 개수를 반환
+    long countByReservation_Experience_Host(Host host);
 
     // 예약 ID로 리뷰가 이미 작성되었는지 확인
     Optional<Review> findByReservationId(Long reservationId);


### PR DESCRIPTION
## 배경
- 지도 위에 호스트를 나타내기 위해서
- 체험 등록 시 호스트 자신의 정보가 필요

## 작업사항
- 호스트 전체 리스트 조회 구현 (37c4dab2fe5d6af6de12cced7679792c1df2d36c, ed3b96221e363c742f63d4d3d87e3d5b073941d6)
- 호스트 자신의 정보 조회 구현 (fc678a309e193d47313dc7ad3ad82b2b5617d369, ed3b96221e363c742f63d4d3d87e3d5b073941d6)