### PR TITLE
Fix : 체험 생성 시 이미지 첨부 로직 분리

### DIFF
--- a/src/main/java/com/InFrame/domains/experience/controller/ExperienceController.java
+++ b/src/main/java/com/InFrame/domains/experience/controller/ExperienceController.java
@@ -5,6 +5,8 @@ import com.InFrame.domains.experience.reqdto.ExperienceRequestDto;
 import com.InFrame.domains.experience.resdto.ExperienceResponseDto;
 import com.InFrame.domains.experience.service.ExperienceService;
 import com.InFrame.security.userdetails.UserDetailsImpl;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.ai.vectorstore.VectorStore;
@@ -13,6 +15,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -31,20 +34,34 @@ public class ExperienceController implements ExperienceApi {
     private final ExperienceService experienceService;
 
     @Override
-    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping
     public ResponseEntity<?> createExperience(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
-            @RequestPart("requestDto") ExperienceRequestDto requestDto,
+            @Valid
+            @RequestBody ExperienceRequestDto requestDto
+    ) {
+        ExperienceResponseDto response = experienceService.createExperience(
+                userDetails.getUser(), requestDto
+        );
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    @PostMapping(value = "/{experienceId}/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<?> uploadExperienceImages(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable Long experienceId,
             @RequestPart("images") List<MultipartFile> images
     ) {
-        ExperienceResponseDto responseDto = experienceService.createExperience(
-                userDetails.getUser(), requestDto, images);
-        return ResponseEntity.ok(responseDto);
+        ExperienceResponseDto response = experienceService.uploadExperienceImages(
+                userDetails.getUser(), experienceId, images
+        );
+        return ResponseEntity.ok(response);
     }
 
     @Override
     @GetMapping("/recommend")
-    public ResponseEntity<List<ExperienceResponseDto>> recommendExperiences(
+    public ResponseEntity<?> recommendExperiences(
             @RequestParam("query") String query,
             @RequestParam(value = "topK", defaultValue = "5") int topK
     ) {

--- a/src/main/java/com/InFrame/domains/experience/controller/api/ExperienceApi.java
+++ b/src/main/java/com/InFrame/domains/experience/controller/api/ExperienceApi.java
@@ -6,6 +6,7 @@ import com.InFrame.security.userdetails.UserDetailsImpl;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -13,9 +14,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -26,29 +30,52 @@ import java.util.List;
 @Tag(name = "Experience API", description = "체험 관련 API")
 public interface ExperienceApi {
 
-    @Operation(summary = "체험 생성", description = "호스트가 새로운 체험을 생성하는 기능입니다.")
+    @Operation(summary = "체험 생성", description = "새로운 체험을 텍스트 정보로 먼저 등록합니다. (이미지 제외)")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "체험 생성 성공",
-                    content = @Content(schema = @Schema(implementation = ExperienceResponseDto.class))),
-            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
-            @ApiResponse(responseCode = "403", description = "호스트가 아님"),
-            @ApiResponse(responseCode = "404", description = "호스트 정보를 찾을 수 없음")
+                    content = @Content(schema = @Schema(implementation = ExperienceResponseDto.class)))
     })
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<?> createExperience(
             @Parameter(hidden = true)
             @AuthenticationPrincipal UserDetailsImpl userDetails,
 
-            @Parameter(description = "체험 정보")
-            @RequestPart("requestDto") ExperienceRequestDto requestDto,
+            @Valid
+            @RequestBody
+            @Parameter(description = "체험 정보 DTO")
+            ExperienceRequestDto requestDto
+    );
 
-            @Parameter(description = "체험 이미지 파일 목록")
-            @RequestPart("images") List<MultipartFile> images);
+
+    @Operation(summary = "체험 이미지 업로드", description = "생성된 체험 ID에 이미지 파일들을 업로드합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "이미지 업로드 성공",
+                    content = @Content(schema = @Schema(implementation = ExperienceResponseDto.class)))
+    })
+    ResponseEntity<?> uploadExperienceImages(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+
+            @Parameter(description = "이미지를 업로드할 체험 ID")
+            @PathVariable Long experienceId,
+
+            @RequestPart("images")
+            @Parameter(
+                    description = "체험 이미지 파일 목록",
+                    content = @Content(
+                            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                            array = @ArraySchema(
+                                    schema = @Schema(type = "string", format = "binary")
+                            )
+                    )
+            )
+            List<MultipartFile> images
+    );
 
 
     @Operation(summary = "AI 체험 추천", description = "검색 쿼리와 유사한 체험을 AI가 추천합니다.")
     @ApiResponse(responseCode = "200", description = "추천 목록 조회 성공")
-    @GetMapping("/recommend")
-    ResponseEntity<List<ExperienceResponseDto>> recommendExperiences(
+    ResponseEntity<?> recommendExperiences(
             @Parameter(name = "query", in = ParameterIn.QUERY, required = true, description = "검색어 (예: 친구와 둘이 시험 끝나고 감성 있게 즐기기 좋은 체험)")
             @RequestParam("query") String query,
 

--- a/src/main/java/com/InFrame/domains/experience/reqdto/ExperienceRequestDto.java
+++ b/src/main/java/com/InFrame/domains/experience/reqdto/ExperienceRequestDto.java
@@ -1,7 +1,6 @@
 package com.InFrame.domains.experience.reqdto;
 
 import com.InFrame.domains.experience.entity.Experience;
-import com.InFrame.domains.host.entity.enums.Category;
 import com.InFrame.domains.experience.entity.enums.DetailField;
 import com.InFrame.domains.experience.entity.enums.ProfessionalField;
 import com.InFrame.domains.host.entity.Host;
@@ -16,10 +15,6 @@ import java.util.Set;
 
 @Schema(description = "체험 생성 요청 DTO")
 public record ExperienceRequestDto (
-        @Schema(description = "분야 카테고리")
-        @NotNull(message = "분야 카테고리는 필수입니다.")
-        Category category,
-
         @Schema(description = "전문분야")
         @NotNull(message = "전문분야는 필수입니다.")
         ProfessionalField professionalField,

--- a/src/main/java/com/InFrame/domains/experience/service/ExperienceService.java
+++ b/src/main/java/com/InFrame/domains/experience/service/ExperienceService.java
@@ -35,7 +35,7 @@ public class ExperienceService {
 
     // 체험 생성
     @Transactional
-    public ExperienceResponseDto createExperience(User user, ExperienceRequestDto requestDto, List<MultipartFile> images) {
+    public ExperienceResponseDto createExperience(User user, ExperienceRequestDto requestDto) {
         if (user.getRole() != Role.HOST) {
             throw new CustomException(ErrorCode.FORBIDDEN_ACCESS);
         }
@@ -49,19 +49,35 @@ public class ExperienceService {
         Experience experience = requestDto.toEntity(host);
         Experience savedExperience = experienceRepository.save(experience);
 
-        String folderName = "experiences/" + savedExperience.getId();
+        // VectorDB에 체험 정보 인덱싱
+        indexExperience(savedExperience);
+
+        return  ExperienceResponseDto.from(savedExperience, host);
+    }
+
+    // 체험 이미지 업로드
+    @Transactional
+    public ExperienceResponseDto uploadExperienceImages(User user, Long experienceId, List<MultipartFile> images) {
+        // 1. 체험 정보 조회
+        Experience experience = experienceRepository.findById(experienceId)
+                .orElseThrow(() -> new CustomException(ErrorCode.EXPERIENCE_NOT_FOUND));
+
+        // 2. 권한 확인
+        if (user.getRole() != Role.HOST || !Objects.equals(experience.getHost().getId(), user.getHost().getId())) {
+            throw new CustomException(ErrorCode.FORBIDDEN_ACCESS);
+        }
+
+        // 3. S3 업로드
+        String folderName = "experiences/" + experience.getId();
         List<String> imageUrls = images.stream()
                 .map(file -> s3UploadService.uploadFile(file, folderName))
                 .collect(Collectors.toList());
 
-        // 이미지 URL 리스트를 엔티티에 업데이트 및 DB 재저장
-        savedExperience.updateImageUrls(imageUrls);
-        Experience updatedExperience = experienceRepository.save(savedExperience);
+        // 4. 이미지 URL 업데이트 및 저장
+        experience.updateImageUrls(imageUrls);
+        Experience updatedExperience = experienceRepository.save(experience);
 
-        // VectorDB에 체험 정보 인덱싱
-        indexExperience(savedExperience);
-
-        return  ExperienceResponseDto.from(updatedExperience, host);
+        return ExperienceResponseDto.from(updatedExperience, updatedExperience.getHost());
     }
 
     // AI 기반 체험 추천


### PR DESCRIPTION
## 배경
- 체험 생성 시 JSON 데이터와 이미지 파일을 한 번에 보낼 때 오류가 발생해서 체험 생성과 이미지 첨부를 분리

## 작업사항
- 이미지 업로드와 체험 생성 분리 (6cc6a04cbfa666708320fbfc5f251829e34047f6)