### PR TITLE
Fix : 업체 로고 업로드 시 권한 확인 제거

### DIFF
--- a/src/main/java/com/InFrame/domains/host/service/HostService.java
+++ b/src/main/java/com/InFrame/domains/host/service/HostService.java
@@ -66,27 +66,22 @@ public class HostService {
     // 업체 로고 이미지 업로드
     @Transactional
     public String uploadCompanyLogo(User user, MultipartFile file) {
-        // 1. 호스트 권한 확인
-        if (user.getRole() != Role.HOST) {
-            throw new CustomException(ErrorCode.FORBIDDEN_ACCESS);
-        }
-
-        // 2. 호스트 정보 가져오기
+        // 1. 호스트 정보 가져오기
         Host host = user.getHost();
         if (host == null) {
             throw new CustomException(ErrorCode.HOST_NOT_FOUND);
         }
 
-        // 3. 기존 로고 이미지가 있다면 S3에서 삭제
+        // 2. 기존 로고 이미지가 있다면 S3에서 삭제
         String oldLogoUrl = host.getCompanyLogoUrl();
         if (oldLogoUrl != null && !oldLogoUrl.isEmpty()) {
             s3UploadService.deleteFile(oldLogoUrl);
         }
 
-        // 4. 새 로고 이미지 S3에 업로드
+        // 3. 새 로고 이미지 S3에 업로드
         String newLogoUrl = s3UploadService.uploadFile(file, "logo");
 
-        // 5. 호스트 정보에 새 이미지 URL 업데이트
+        // 4. 호스트 정보에 새 이미지 URL 업데이트
         host.updateCompanyLogo(newLogoUrl);
         hostRepository.save(host);
 


### PR DESCRIPTION
## 배경
- 회사 로고 업로드 시 권한이 필요 없게 해야 함

## 작업사항
- 권한 확인 로직 제거 (e549b5cb6303d6ddb74c1ac234abc0a0e7142ed5)