### PR TITLE
Feature : 체험, 호스트 좋아요 로직 구현

### DIFF
--- a/src/main/java/com/InFrame/domains/experience/entity/Experience.java
+++ b/src/main/java/com/InFrame/domains/experience/entity/Experience.java
@@ -3,6 +3,8 @@ package com.InFrame.domains.experience.entity;
 import com.InFrame.domains.experience.entity.enums.DetailField;
 import com.InFrame.domains.experience.entity.enums.ProfessionalField;
 import com.InFrame.domains.host.entity.Host;
+import com.InFrame.domains.like.entity.ExperienceLike;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
@@ -15,6 +17,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -84,6 +87,9 @@ public class Experience {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "host_id")
     private Host host;
+
+    @OneToMany(mappedBy = "experience", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<ExperienceLike> likes = new HashSet<>();
 
     @Builder
     public Experience(ProfessionalField professionalField,

--- a/src/main/java/com/InFrame/domains/experience/repository/ExperienceRepository.java
+++ b/src/main/java/com/InFrame/domains/experience/repository/ExperienceRepository.java
@@ -4,6 +4,7 @@ import com.InFrame.domains.experience.entity.Experience;
 import com.InFrame.domains.host.entity.Host;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -18,4 +19,9 @@ public interface ExperienceRepository extends JpaRepository<Experience, Long> {
     // 체험을 가진 호스트 조회
     @Query("SELECT DISTINCT e.host FROM Experience e")
     List<Host> findDistinctHostsWithExperiences();
+
+    @Query("SELECT DISTINCT e FROM Experience e " +
+            "LEFT JOIN FETCH e.imageUrls " +
+            "WHERE e.host IN :hosts")
+    List<Experience> findAllByHostInWithImages(@Param("hosts") List<Host> hosts);
 }

--- a/src/main/java/com/InFrame/domains/experience/resdto/ExperienceLikeResponseDto.java
+++ b/src/main/java/com/InFrame/domains/experience/resdto/ExperienceLikeResponseDto.java
@@ -1,42 +1,22 @@
 package com.InFrame.domains.experience.resdto;
 
 import com.InFrame.domains.experience.entity.Experience;
-import com.InFrame.domains.experience.entity.enums.DetailField;
-import com.InFrame.domains.experience.entity.enums.ProfessionalField;
 import com.InFrame.domains.host.entity.Host;
 import com.InFrame.domains.review.entity.Review;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
-@Schema(description = "체험 상세 정보 응답 DTO")
-public record ExperienceDetailResponseDto(
+@Schema(description = "체험 좋아요 정보 응답 DTO")
+public record ExperienceLikeResponseDto(
         @Schema(description = "체험 ID")
         Long experienceId,
 
         @Schema(description = "체험 제목")
         String title,
 
-        @Schema(description = "호스트 이미지")
-        String hostProfile,
-
         @Schema(description = "호스트 이름")
         String hostName,
-
-        @Schema(description = "호스트 자기소개")
-        String hostIntro,
-
-        @Schema(description = "체험 소개")
-        String experienceIntro,
-
-        @Schema(description = "전문 분야")
-        ProfessionalField professionalField,
-
-        @Schema(description = "세부 분야")
-        DetailField detailField,
-
-        @Schema(description = "장소")
-        String location,
 
         @Schema(description = "가격")
         int price,
@@ -44,16 +24,14 @@ public record ExperienceDetailResponseDto(
         @Schema(description = "평균 평점")
         double rating,
 
-        @Schema(description = "리뷰 총 개수")
-        int reviewCount,
-
         @Schema(description = "체험 이미지 URL 목록")
         List<String> imageUrls
 ) {
-    public static ExperienceDetailResponseDto from(
+    public static ExperienceLikeResponseDto from(
             Experience experience,
             Host host,
             List<Review> reviewEntities
+
     ) {
         int reviewCount = reviewEntities.size();
         double rating = 0.0;
@@ -65,19 +43,12 @@ public record ExperienceDetailResponseDto(
             rating = Math.round(rating * 10.0) / 10.0;
         }
 
-        return new ExperienceDetailResponseDto(
+        return new ExperienceLikeResponseDto(
                 experience.getId(),
                 experience.getTitle(),
-                host.getUser().getProfileImageUrl(),
                 host.getUser().getName(),
-                host.getDescription(),
-                experience.getDescription(),
-                experience.getProfessionalField(),
-                experience.getDetailField(),
-                host.getAddressBase(),
                 experience.getPrice(),
                 rating,
-                reviewCount,
                 experience.getImageUrls()
         );
     }

--- a/src/main/java/com/InFrame/domains/host/entity/Host.java
+++ b/src/main/java/com/InFrame/domains/host/entity/Host.java
@@ -1,7 +1,9 @@
 package com.InFrame.domains.host.entity;
 
 import com.InFrame.domains.host.entity.enums.Category;
+import com.InFrame.domains.like.entity.HostLike;
 import com.InFrame.domains.user.entity.User;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -11,6 +13,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import lombok.Builder;
 import lombok.Cleanup;
@@ -18,6 +21,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalTime;
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity
 @Getter
@@ -80,6 +85,9 @@ public class Host {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user; // User 와 1:1
+
+    @OneToMany(mappedBy = "host", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<HostLike> likes = new HashSet<>();
 
     @Builder
     public Host(String businessName, String businessPhoneNumber, Category category,

--- a/src/main/java/com/InFrame/domains/host/resdto/HostLikeResponseDto.java
+++ b/src/main/java/com/InFrame/domains/host/resdto/HostLikeResponseDto.java
@@ -1,0 +1,41 @@
+package com.InFrame.domains.host.resdto;
+
+import com.InFrame.domains.experience.entity.Experience;
+import com.InFrame.domains.host.entity.Host;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Schema(description = "호스트 좋아요 정보 응답 DTO")
+public record HostLikeResponseDto(
+        @Schema(description = "호스트 ID")
+        Long hostId,
+
+        @Schema(description = "호스트 본명")
+        String hostName,
+
+        @Schema(description = "호스트 프로필 이미지")
+        String profileImageUrl,
+
+        @Schema(description = "호스트가 등록한 체험 이미지 URL 목록")
+        List<String> experienceImageUrls
+) {
+    public static HostLikeResponseDto from(
+            Host host,
+            List<Experience> experiences
+    ) {
+        List<String> allImages = experiences.stream()
+                .map(Experience::getImageUrls)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
+
+        return new HostLikeResponseDto(
+                host.getId(),
+                host.getUser().getName(),
+                host.getUser().getProfileImageUrl(),
+                allImages
+        );
+    }
+}

--- a/src/main/java/com/InFrame/domains/host/service/HostService.java
+++ b/src/main/java/com/InFrame/domains/host/service/HostService.java
@@ -68,9 +68,6 @@ public class HostService {
     public String uploadCompanyLogo(User user, MultipartFile file) {
         // 1. 호스트 정보 가져오기
         Host host = user.getHost();
-        if (host == null) {
-            throw new CustomException(ErrorCode.HOST_NOT_FOUND);
-        }
 
         // 2. 기존 로고 이미지가 있다면 S3에서 삭제
         String oldLogoUrl = host.getCompanyLogoUrl();

--- a/src/main/java/com/InFrame/domains/like/controller/LikeController.java
+++ b/src/main/java/com/InFrame/domains/like/controller/LikeController.java
@@ -1,0 +1,66 @@
+package com.InFrame.domains.like.controller;
+
+import com.InFrame.domains.experience.resdto.ExperienceLikeResponseDto;
+import com.InFrame.domains.host.resdto.HostLikeResponseDto;
+import com.InFrame.domains.like.controller.api.LikeApi;
+import com.InFrame.domains.like.service.LikeService;
+import com.InFrame.security.userdetails.UserDetailsImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/likes")
+public class LikeController implements LikeApi {
+    private final LikeService likeService;
+
+    @Override
+    @PostMapping("/experience/{experienceId}")
+    public ResponseEntity<String> toggleExperienceLike(
+            @PathVariable Long experienceId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        boolean liked = likeService.toggleExperienceLike(userDetails.getUser().getId(), experienceId);
+        String message = liked ? "체험을 좋아합니다." : "체험 좋아요를 취소합니다.";
+        return ResponseEntity.ok(message);
+    }
+
+    @Override
+    @PostMapping("/host/{hostId}")
+    public ResponseEntity<String> toggleHostLike(
+            @PathVariable Long hostId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        boolean liked = likeService.toggleHostLike(userDetails.getUser().getId(), hostId);
+        String message = liked ? "호스트를 좋아합니다." : "호스트 좋아요를 취소합니다.";
+        return ResponseEntity.ok(message);
+    }
+
+    @Override
+    @GetMapping("/experience")
+    public ResponseEntity<?> getMyLikedExperiences(
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        List<ExperienceLikeResponseDto> likedExperiences =
+                likeService.getMyLikedExperiences(userDetails.getUser().getId());
+        return ResponseEntity.ok(likedExperiences);
+    }
+
+    @Override
+    @GetMapping("/host")
+    public ResponseEntity<?> getMyLikedHosts(
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        List<HostLikeResponseDto> likedHosts =
+                likeService.getMyLikedHosts(userDetails.getUser().getId());
+        return ResponseEntity.ok(likedHosts);
+    }
+}

--- a/src/main/java/com/InFrame/domains/like/controller/api/LikeApi.java
+++ b/src/main/java/com/InFrame/domains/like/controller/api/LikeApi.java
@@ -1,0 +1,76 @@
+package com.InFrame.domains.like.controller.api;
+
+import com.InFrame.domains.experience.resdto.ExperienceLikeResponseDto;
+import com.InFrame.domains.host.resdto.HostLikeResponseDto;
+import com.InFrame.security.userdetails.UserDetailsImpl;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "Like API", description = "하트(체험, 호스트) 관련 API")
+public interface LikeApi {
+
+    @Operation(summary = "체험 '하트' 토글", description = "특정 체험에 대해 '하트'를 누르거나 취소합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "'하트' 성공 또는 취소 성공",
+                    content = @Content(schema = @Schema(implementation = String.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content),
+            @ApiResponse(responseCode = "404", description = "사용자 또는 체험을 찾을 수 없음", content = @Content)
+    })
+    ResponseEntity<?> toggleExperienceLike(
+            @Parameter(description = "하트를 누를 체험의 ID", required = true)
+            @PathVariable Long experienceId,
+
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    );
+
+    @Operation(summary = "호스트 '하트' 토글", description = "특정 호스트에 대해 '하트'를 누르거나 취소합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "'하트' 성공 또는 취소 성공",
+                    content = @Content(schema = @Schema(implementation = String.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content),
+            @ApiResponse(responseCode = "404", description = "사용자 또는 호스트를 찾을 수 없음", content = @Content)
+    })
+    ResponseEntity<?> toggleHostLike(
+            @Parameter(description = "하트를 누를 호스트의 ID", required = true)
+            @PathVariable Long hostId,
+
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    );
+
+    @Operation(summary = "내가 '하트' 누른 체험 목록 조회", description = "현재 인증된 사용자가 '하트'를 누른 모든 체험 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(mediaType = "application/json",
+                            array = @ArraySchema(schema = @Schema(implementation = ExperienceLikeResponseDto.class)))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음", content = @Content)
+    })
+    ResponseEntity<?> getMyLikedExperiences(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    );
+
+    @Operation(summary = "내가 '하트' 누른 호스트 목록 조회", description = "현재 인증된 사용자가 '하트'를 누른 모든 호스트 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(mediaType = "application/json",
+                            array = @ArraySchema(schema = @Schema(implementation = HostLikeResponseDto.class)))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음", content = @Content)
+    })
+    ResponseEntity<?> getMyLikedHosts(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    );
+}

--- a/src/main/java/com/InFrame/domains/like/entity/ExperienceLike.java
+++ b/src/main/java/com/InFrame/domains/like/entity/ExperienceLike.java
@@ -1,0 +1,37 @@
+package com.InFrame.domains.like.entity;
+
+import com.InFrame.domains.experience.entity.Experience;
+import com.InFrame.domains.user.entity.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class ExperienceLike {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "experience_id", nullable = false)
+    private Experience experience;
+
+    @Builder
+    public ExperienceLike(User user, Experience experience) {
+        this.user = user;
+        this.experience = experience;
+    }
+}

--- a/src/main/java/com/InFrame/domains/like/entity/HostLike.java
+++ b/src/main/java/com/InFrame/domains/like/entity/HostLike.java
@@ -1,0 +1,37 @@
+package com.InFrame.domains.like.entity;
+
+import com.InFrame.domains.host.entity.Host;
+import com.InFrame.domains.user.entity.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class HostLike {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "host_id", nullable = false)
+    private Host host;
+
+    @Builder
+    public HostLike(User user, Host host) {
+        this.user = user;
+        this.host = host;
+    }
+}

--- a/src/main/java/com/InFrame/domains/like/repository/ExperienceLikeRepository.java
+++ b/src/main/java/com/InFrame/domains/like/repository/ExperienceLikeRepository.java
@@ -1,0 +1,26 @@
+package com.InFrame.domains.like.repository;
+
+import com.InFrame.domains.experience.entity.Experience;
+import com.InFrame.domains.like.entity.ExperienceLike;
+import com.InFrame.domains.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ExperienceLikeRepository extends JpaRepository<ExperienceLike, Long> {
+
+    // 유저와 체험 객체로 좋아요 찾기
+    Optional<ExperienceLike> findByUserAndExperience(User user, Experience experience);
+
+    // 특정 유저가 누른 모든 '하트'를 '체험' 정보와 함께 조회
+    @Query("SELECT DISTINCT el FROM ExperienceLike el " +
+            "JOIN FETCH el.experience ex " +
+            "LEFT JOIN FETCH ex.imageUrls " +
+            "JOIN FETCH ex.host h " +
+            "JOIN FETCH h.user " +
+            "WHERE el.user = :user")
+    List<ExperienceLike> findAllByUserWithExperienceAndHost(@Param("user") User user);
+}

--- a/src/main/java/com/InFrame/domains/like/repository/HostLikeRepository.java
+++ b/src/main/java/com/InFrame/domains/like/repository/HostLikeRepository.java
@@ -1,0 +1,24 @@
+package com.InFrame.domains.like.repository;
+
+import com.InFrame.domains.host.entity.Host;
+import com.InFrame.domains.like.entity.HostLike;
+import com.InFrame.domains.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface HostLikeRepository extends JpaRepository<HostLike, Long> {
+
+    // 유저와 호스트 객체로 좋아요 찾기
+    Optional<HostLike> findByUserAndHost(User user, Host host);
+
+    // 특정 유저가 누른 모든 '하트'를 '호스트' 정보와 함께 조회
+    @Query("SELECT hl FROM HostLike hl " +
+            "JOIN FETCH hl.host h " +
+            "LEFT JOIN FETCH h.user " + // Host의 User 정보까지 한 번에 가져옴
+            "WHERE hl.user = :user")
+    List<HostLike> findAllByUserWithHostAndUser(@Param("user") User user);
+}

--- a/src/main/java/com/InFrame/domains/like/service/LikeService.java
+++ b/src/main/java/com/InFrame/domains/like/service/LikeService.java
@@ -1,0 +1,165 @@
+package com.InFrame.domains.like.service;
+
+import com.InFrame.common.exception.CustomException;
+import com.InFrame.common.exception.error.ErrorCode;
+import com.InFrame.domains.experience.entity.Experience;
+import com.InFrame.domains.experience.repository.ExperienceRepository;
+import com.InFrame.domains.experience.resdto.ExperienceLikeResponseDto;
+import com.InFrame.domains.host.entity.Host;
+import com.InFrame.domains.host.repository.HostRepository;
+import com.InFrame.domains.host.resdto.HostLikeResponseDto;
+import com.InFrame.domains.like.entity.ExperienceLike;
+import com.InFrame.domains.like.entity.HostLike;
+import com.InFrame.domains.like.repository.ExperienceLikeRepository;
+import com.InFrame.domains.like.repository.HostLikeRepository;
+import com.InFrame.domains.review.entity.Review;
+import com.InFrame.domains.review.repository.ReviewRepository;
+import com.InFrame.domains.user.entity.User;
+import com.InFrame.domains.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LikeService {
+    private final UserRepository userRepository;
+    private final ExperienceRepository experienceRepository;
+    private final HostRepository hostRepository;
+    private final ExperienceLikeRepository experienceLikeRepository;
+    private final HostLikeRepository hostLikeRepository;
+    private final ReviewRepository reviewRepository;
+
+    @Transactional
+    public boolean toggleExperienceLike(Long userId, Long experienceId) {
+        User user = findUserById(userId);
+        Experience experience = findExperienceById(experienceId);
+
+        // 이미 '좋아요'를 눌렀는지 확인
+        Optional<ExperienceLike> like = experienceLikeRepository.findByUserAndExperience(user, experience);
+
+        if (like.isPresent()) {
+            experienceLikeRepository.delete(like.get());
+            return false;
+        } else {
+            ExperienceLike newLike = ExperienceLike.builder()
+                    .user(user)
+                    .experience(experience)
+                    .build();
+            experienceLikeRepository.save(newLike);
+            return true;
+        }
+    }
+
+    @Transactional
+    public boolean toggleHostLike(Long userId, Long hostId) {
+        User user = findUserById(userId);
+        Host host = findHostById(hostId);
+
+        // 이미 '좋아요'를 눌렀는지 확인
+        Optional<HostLike> like = hostLikeRepository.findByUserAndHost(user, host);
+
+        if (like.isPresent()) {
+            hostLikeRepository.delete(like.get());
+            return false;
+        } else {
+            HostLike newLike = HostLike.builder()
+                    .user(user)
+                    .host(host)
+                    .build();
+            hostLikeRepository.save(newLike);
+            return true;
+        }
+    }
+
+    // 내가 '하트' 누른 체험 목록 조회
+    public List<ExperienceLikeResponseDto> getMyLikedExperiences(Long userId) {
+        User user = findUserById(userId);
+
+        // 1. '좋아요', 체험, 호스트, 호스트 유저 정보를 한 번에 가져옴
+        List<ExperienceLike> likes = experienceLikeRepository.findAllByUserWithExperienceAndHost(user);
+
+        if (likes.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        // 2. '체험' 엔티티 목록만 추출
+        List<Experience> experiences = likes.stream()
+                .map(ExperienceLike::getExperience)
+                .toList();
+
+        // 3. '체험' 목록에 해당하는 모든 '리뷰'를 한 번에 가져옴
+        List<Review> allReviews = reviewRepository.findAllByExperienceInWithExperience(experiences);
+
+        // 4. 리뷰 목록을 체험별로 그룹화
+        Map<Experience, List<Review>> reviewsByExperience = allReviews.stream()
+                .collect(Collectors.groupingBy(
+                        review -> review.getReservation().getExperience()
+                ));
+
+        return likes.stream()
+                .map(like -> {
+                    Experience experience = like.getExperience();
+                    Host host = experience.getHost();
+                    List<Review> reviews = reviewsByExperience.getOrDefault(experience, Collections.emptyList());
+
+                    return ExperienceLikeResponseDto.from(experience, host, reviews);
+                })
+                .collect(Collectors.toList());
+    }
+
+    public List<HostLikeResponseDto> getMyLikedHosts(Long userId) {
+        User user = findUserById(userId);
+
+        // 1. '좋아요', '호스트', '호스트 유저' 정보를 한 번에 가져옴
+        List<HostLike> likes = hostLikeRepository.findAllByUserWithHostAndUser(user);
+
+        if (likes.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        // 2. '좋아요' 목록에서 '호스트' 엔티티 목록만 추출
+        List<Host> hosts = likes.stream()
+                .map(HostLike::getHost)
+                .toList();
+
+        // 3. 추출된 '호스트' 목록에 해당하는 모든 '체험'과 '체험 이미지'를 한 번에 가져옴
+        List<Experience> allExperiences = experienceRepository.findAllByHostInWithImages(hosts);
+
+        // 4. 체험 목록을 호스트별로 그룹화
+        Map<Host, List<Experience>> experiencesByHost = allExperiences.stream()
+                .collect(Collectors.groupingBy(Experience::getHost));
+
+        return likes.stream()
+                .map(like -> {
+                    Host host = like.getHost();
+
+                    List<Experience> experiences = experiencesByHost.getOrDefault(host, Collections.emptyList());
+
+                    return HostLikeResponseDto.from(host, experiences);
+                })
+                .collect(Collectors.toList());
+    }
+
+    private User findUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    private Experience findExperienceById(Long experienceId) {
+        return experienceRepository.findById(experienceId)
+                .orElseThrow(() -> new CustomException(ErrorCode.EXPERIENCE_NOT_FOUND));
+    }
+
+    private Host findHostById(Long hostId) {
+        return hostRepository.findById(hostId)
+                .orElseThrow(() -> new CustomException(ErrorCode.HOST_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/InFrame/domains/review/repository/ReviewRepository.java
+++ b/src/main/java/com/InFrame/domains/review/repository/ReviewRepository.java
@@ -1,5 +1,6 @@
 package com.InFrame.domains.review.repository;
 
+import com.InFrame.domains.experience.entity.Experience;
 import com.InFrame.domains.host.entity.Host;
 import com.InFrame.domains.review.entity.Review;
 import com.InFrame.domains.review.resdto.ReviewResponseDto;
@@ -17,6 +18,13 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     // 예약 ID로 리뷰가 이미 작성되었는지 확인
     Optional<Review> findByReservationId(Long reservationId);
+
+    // 좋아요 조회 기능용
+    @Query("SELECT r FROM Review r " +
+            "JOIN FETCH r.reservation res " +
+            "JOIN FETCH res.experience exp " +
+            "WHERE exp IN :experiences")
+    List<Review> findAllByExperienceInWithExperience(@Param("experiences") List<Experience> experiences);
 
     @Query("SELECT r FROM Review r " +
             "JOIN FETCH r.user u " + // DTO 변환 시 N+1 방지

--- a/src/main/java/com/InFrame/domains/user/entity/User.java
+++ b/src/main/java/com/InFrame/domains/user/entity/User.java
@@ -1,6 +1,8 @@
 package com.InFrame.domains.user.entity;
 
 import com.InFrame.domains.host.entity.Host;
+import com.InFrame.domains.like.entity.ExperienceLike;
+import com.InFrame.domains.like.entity.HostLike;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -9,10 +11,14 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity
 @Getter
@@ -49,6 +55,12 @@ public class User {
 
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private Host host;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<ExperienceLike> experienceLikes = new HashSet<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<HostLike> hostLikes = new HashSet<>();
 
     public void updateRole(Role role) {
         this.role = role;


### PR DESCRIPTION
## 배경
- 유저가 호스트와 체험 좋아요 기능을 필요로 함

## 작업사항
- 좋아요 관련 엔티티 (ed6d804a799b8a27c14570231ab55bdce2159839, a87ed4dbe5dfa2abc743d56303c065080b8a5e7f)
- 좋아요 관련 로직 (a9853695ebd86a6b937026596e8db74805e09eb1)
- 체험, 호스트 응답 DTO 추가 (76161ace75c5e232ce96290b1eda1eb3ae8a880d, afac0587821c725aa565d0c93a8742377af837e2)